### PR TITLE
feat: Add claude-trace integration for debugging and monitoring support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -407,6 +407,27 @@ Self-improvement and learning capture
 
 ## Available Tools
 
+### Claude-Trace Integration
+
+Enable debugging and monitoring with claude-trace:
+
+```bash
+# Enable claude-trace mode
+export AMPLIHACK_USE_TRACE=1
+
+# Run normally - will use claude-trace if available
+amplihack
+
+# Disable (default)
+unset AMPLIHACK_USE_TRACE
+```
+
+The framework automatically:
+
+- Detects when claude-trace should be used
+- Attempts to install claude-trace via npm if needed
+- Falls back to regular claude if unavailable
+
 ### GitHub Issue Creation
 
 Create GitHub issues programmatically:

--- a/examples/claude_trace_example.py
+++ b/examples/claude_trace_example.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""
+Example demonstrating claude-trace integration usage.
+
+This example shows how to use the simple claude-trace integration
+for debugging and monitoring Claude Code interactions.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+# Add src to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from amplihack.utils.claude_trace import get_claude_command, should_use_trace
+
+
+def main():
+    """Demonstrate claude-trace integration."""
+    print("🔍 Claude-Trace Integration Example")
+    print("=" * 50)
+
+    # 1. Basic Usage - Check Current State
+    print("\n📋 Current Configuration:")
+    print("-" * 30)
+
+    print(f"AMPLIHACK_USE_TRACE: {os.getenv('AMPLIHACK_USE_TRACE', 'not set')}")
+    print(f"Should use trace: {should_use_trace()}")
+    print(f"Claude command: {get_claude_command()}")
+
+    # 2. Enable Trace Mode
+    print("\n🔧 Enabling Trace Mode:")
+    print("-" * 30)
+
+    # Set environment variable
+    os.environ["AMPLIHACK_USE_TRACE"] = "1"
+    print("Set AMPLIHACK_USE_TRACE=1")
+    print(f"Should use trace: {should_use_trace()}")
+    print(f"Claude command: {get_claude_command()}")
+
+    # 3. Disable Trace Mode
+    print("\n🔧 Disabling Trace Mode:")
+    print("-" * 30)
+
+    # Unset environment variable
+    if "AMPLIHACK_USE_TRACE" in os.environ:
+        del os.environ["AMPLIHACK_USE_TRACE"]
+    print("Unset AMPLIHACK_USE_TRACE")
+    print(f"Should use trace: {should_use_trace()}")
+    print(f"Claude command: {get_claude_command()}")
+
+    # 4. Usage Instructions
+    print("\n📖 Usage Instructions:")
+    print("-" * 30)
+    print("To enable claude-trace:")
+    print("  export AMPLIHACK_USE_TRACE=1")
+    print("  # OR")
+    print("  AMPLIHACK_USE_TRACE=1 amplihack")
+    print()
+    print("To disable (default):")
+    print("  unset AMPLIHACK_USE_TRACE")
+    print("  # OR")
+    print("  export AMPLIHACK_USE_TRACE=0")
+
+    print("\n" + "=" * 50)
+    print("🎉 Claude-Trace Example Complete!")
+    print()
+    print("Key Features:")
+    print("  ✅ Simple environment variable control")
+    print("  ✅ Automatic claude-trace installation")
+    print("  ✅ Graceful fallback to regular claude")
+    print("  ✅ No configuration files needed")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/amplihack/launcher/core.py
+++ b/src/amplihack/launcher/core.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import List, Optional
 
 from ..proxy.manager import ProxyManager
+from ..utils.claude_trace import get_claude_command
 from ..uvx.manager import UVXManager
 from .detector import ClaudeDirectoryDetector
 
@@ -87,7 +88,9 @@ class ClaudeLauncher:
         Returns:
             List of command arguments for subprocess.
         """
-        cmd = ["claude", "--dangerously-skip-permissions"]
+        # Use claude-trace if requested and available, otherwise use claude
+        claude_binary = get_claude_command()
+        cmd = [claude_binary, "--dangerously-skip-permissions"]
 
         # Add system prompt if provided
         if self.append_system_prompt and self.append_system_prompt.exists():

--- a/src/amplihack/utils/claude_trace.py
+++ b/src/amplihack/utils/claude_trace.py
@@ -1,0 +1,59 @@
+"""Claude-trace integration - ruthlessly simple implementation."""
+
+import os
+import shutil
+import subprocess
+
+
+def should_use_trace() -> bool:
+    """Check if claude-trace should be used instead of claude."""
+    return os.getenv("AMPLIHACK_USE_TRACE", "").lower() in ("1", "true", "yes")
+
+
+def get_claude_command() -> str:
+    """Get the appropriate claude command (claude or claude-trace).
+
+    Returns:
+        Command name to use ('claude' or 'claude-trace')
+
+    Side Effects:
+        May attempt to install claude-trace via npm if requested but not found
+    """
+    if not should_use_trace():
+        return "claude"
+
+    # Check if claude-trace is available
+    if shutil.which("claude-trace"):
+        return "claude-trace"
+
+    # Try to install claude-trace
+    if _install_claude_trace():
+        return "claude-trace"
+
+    # Fall back to claude
+    return "claude"
+
+
+def _install_claude_trace() -> bool:
+    """Attempt to install claude-trace via npm.
+
+    Returns:
+        True if installation succeeded, False otherwise
+    """
+    try:
+        # Check if npm is available
+        if not shutil.which("npm"):
+            return False
+
+        # Install claude-trace globally
+        result = subprocess.run(
+            ["npm", "install", "-g", "@mariozechner/claude-trace"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+
+        return result.returncode == 0
+
+    except (subprocess.TimeoutExpired, subprocess.SubprocessError):
+        return False

--- a/tests/test_claude_trace.py
+++ b/tests/test_claude_trace.py
@@ -1,0 +1,107 @@
+"""Tests for claude-trace integration."""
+
+import os
+import subprocess
+from unittest.mock import Mock, patch
+
+from amplihack.utils.claude_trace import get_claude_command, should_use_trace
+
+
+class TestClaudeTrace:
+    """Test claude-trace integration."""
+
+    def test_should_use_trace_default_false(self):
+        """By default, trace should not be used."""
+        with patch.dict(os.environ, {}, clear=True):
+            assert not should_use_trace()
+
+    def test_should_use_trace_when_enabled(self):
+        """Trace should be used when environment variable is set."""
+        test_cases = ["1", "true", "yes", "TRUE", "YES"]
+        for value in test_cases:
+            with patch.dict(os.environ, {"AMPLIHACK_USE_TRACE": value}):
+                assert should_use_trace()
+
+    def test_should_use_trace_when_disabled(self):
+        """Trace should not be used when environment variable indicates no."""
+        test_cases = ["0", "false", "no", "FALSE", "NO", "random"]
+        for value in test_cases:
+            with patch.dict(os.environ, {"AMPLIHACK_USE_TRACE": value}):
+                assert not should_use_trace()
+
+    def test_get_claude_command_default(self):
+        """Should return 'claude' by default."""
+        with patch.dict(os.environ, {}, clear=True):
+            assert get_claude_command() == "claude"
+
+    def test_get_claude_command_with_trace_available(self):
+        """Should return 'claude-trace' when available and requested."""
+        with patch.dict(os.environ, {"AMPLIHACK_USE_TRACE": "1"}):
+            with patch("shutil.which", return_value="/usr/bin/claude-trace"):
+                assert get_claude_command() == "claude-trace"
+
+    def test_get_claude_command_with_trace_unavailable(self):
+        """Should fallback to 'claude' when trace unavailable."""
+        with patch.dict(os.environ, {"AMPLIHACK_USE_TRACE": "1"}):
+            with patch("shutil.which", return_value=None):
+                with patch(
+                    "amplihack.utils.claude_trace._install_claude_trace", return_value=False
+                ):
+                    assert get_claude_command() == "claude"
+
+    def test_get_claude_command_with_successful_install(self):
+        """Should return 'claude-trace' after successful installation."""
+        with patch.dict(os.environ, {"AMPLIHACK_USE_TRACE": "1"}):
+            with patch("shutil.which", side_effect=[None, "/usr/bin/claude-trace"]):
+                with patch("amplihack.utils.claude_trace._install_claude_trace", return_value=True):
+                    assert get_claude_command() == "claude-trace"
+
+    @patch("subprocess.run")
+    @patch("shutil.which")
+    def test_install_claude_trace_success(self, mock_which, mock_run):
+        """Test successful claude-trace installation."""
+        from amplihack.utils.claude_trace import _install_claude_trace
+
+        mock_which.return_value = "/usr/bin/npm"
+        mock_run.return_value = Mock(returncode=0)
+
+        assert _install_claude_trace()
+        mock_run.assert_called_once_with(
+            ["npm", "install", "-g", "@mariozechner/claude-trace"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+
+    @patch("subprocess.run")
+    @patch("shutil.which")
+    def test_install_claude_trace_no_npm(self, mock_which, mock_run):
+        """Test installation fails when npm not available."""
+        from amplihack.utils.claude_trace import _install_claude_trace
+
+        mock_which.return_value = None
+
+        assert not _install_claude_trace()
+        mock_run.assert_not_called()
+
+    @patch("subprocess.run")
+    @patch("shutil.which")
+    def test_install_claude_trace_npm_fails(self, mock_which, mock_run):
+        """Test installation fails when npm command fails."""
+        from amplihack.utils.claude_trace import _install_claude_trace
+
+        mock_which.return_value = "/usr/bin/npm"
+        mock_run.return_value = Mock(returncode=1)
+
+        assert not _install_claude_trace()
+
+    @patch("subprocess.run")
+    @patch("shutil.which")
+    def test_install_claude_trace_timeout(self, mock_which, mock_run):
+        """Test installation fails on timeout."""
+        from amplihack.utils.claude_trace import _install_claude_trace
+
+        mock_which.return_value = "/usr/bin/npm"
+        mock_run.side_effect = subprocess.TimeoutExpired("npm", 60)
+
+        assert not _install_claude_trace()


### PR DESCRIPTION
## Summary

Add support for running `claude-trace` instead of `claude` to enable debugging and monitoring capabilities for the Agentic Coding Framework.

## Implementation

This PR introduces a **ruthlessly simple** claude-trace integration that follows the project's philosophy of minimal complexity:

### 🔧 **Core Features**
- **Environment Variable Control**: `AMPLIHACK_USE_TRACE=1` enables claude-trace mode
- **Automatic Installation**: Attempts to install claude-trace via npm when requested but not found
- **Graceful Fallback**: Falls back to regular claude when claude-trace unavailable
- **UVX Compatibility**: Works seamlessly with existing UVX --add-dir functionality

### 📁 **Files Added/Modified**
- `src/amplihack/utils/claude_trace.py` - Core trace detection (59 lines)
- `src/amplihack/launcher/core.py` - Enhanced launcher integration (2 line change)
- `tests/test_claude_trace.py` - Comprehensive test suite (107 lines, 11 test cases)
- `examples/claude_trace_example.py` - Usage demonstration (77 lines)
- `CLAUDE.md` - Updated documentation with usage instructions

### 🧪 **Testing**
- **11 test cases** covering all scenarios with 100% pass rate
- Mock strategies for external dependencies (npm, subprocess)
- Environment variable testing for all supported values
- Installation success/failure scenarios

### 📖 **Usage**

```bash
# Enable claude-trace mode
export AMPLIHACK_USE_TRACE=1

# Run normally - will use claude-trace if available
amplihack

# Disable (default)
unset AMPLIHACK_USE_TRACE
```

### ✅ **Quality Assurance**
- All pre-commit hooks passing
- Follows project's "ruthless simplicity" philosophy
- Zero-BS implementation - no stubs or placeholders
- Preserves backward compatibility
- Maintains UVX integration

## Architecture Decision

This implementation prioritizes **simplicity over flexibility**:
- Single environment variable control (vs complex configuration)
- Direct command substitution (vs abstraction layers)
- Minimal code footprint (59 lines of core logic)
- No configuration files required

## Testing Results

```
============================= test session starts ==============================
tests/test_claude_trace.py::TestClaudeTrace::test_should_use_trace_default_false PASSED
tests/test_claude_trace.py::TestClaudeTrace::test_should_use_trace_when_enabled PASSED
tests/test_claude_trace.py::TestClaudeTrace::test_should_use_trace_when_disabled PASSED
tests/test_claude_trace.py::TestClaudeTrace::test_get_claude_command_default PASSED
tests/test_claude_trace.py::TestClaudeTrace::test_get_claude_command_with_trace_available PASSED
tests/test_claude_trace.py::TestClaudeTrace::test_get_claude_command_with_trace_unavailable PASSED
tests/test_claude_trace.py::TestClaudeTrace::test_get_claude_command_with_successful_install PASSED
tests/test_claude_trace.py::TestClaudeTrace::test_install_claude_trace_success PASSED
tests/test_claude_trace.py::TestClaudeTrace::test_install_claude_trace_no_npm PASSED
tests/test_claude_trace.py::TestClaudeTrace::test_install_claude_trace_npm_fails PASSED
tests/test_claude_trace.py::TestClaudeTrace::test_install_claude_trace_timeout PASSED

============================== 11 passed in 0.10s ==============================
```

## Related Issues

Closes #125

🤖 Generated with [Claude Code](https://claude.ai/code)