### PR TITLE
fix: Pass --claude-path to claude-trace to avoid broken shell wrappers

### DIFF
--- a/src/amplihack/launcher/core.py
+++ b/src/amplihack/launcher/core.py
@@ -215,6 +215,35 @@ class ClaudeLauncher:
         if claude_binary == "claude-trace":
             # claude-trace requires --run-with before Claude arguments
             cmd = [claude_binary]
+
+            # Find the correct claude binary (prefer homebrew over pnpm)
+            import shutil
+
+            claude_path = None
+
+            # Priority order for finding claude binary:
+            # 1. Homebrew on macOS (most reliable)
+            # 2. Standard system locations
+            # 3. Fall back to PATH search (may include problematic wrappers)
+            preferred_paths = [
+                "/opt/homebrew/bin/claude",  # macOS homebrew
+                "/usr/local/bin/claude",  # Linux/WSL standard location
+                "/usr/bin/claude",  # System-wide installation
+            ]
+
+            for path in preferred_paths:
+                if Path(path).exists():
+                    claude_path = path
+                    break
+
+            if not claude_path:
+                # Fall back to any claude in PATH
+                claude_path = shutil.which("claude")
+
+            # Add --claude-path if we found a claude binary
+            if claude_path:
+                cmd.extend(["--claude-path", claude_path])
+
             claude_args = ["--dangerously-skip-permissions"]
 
             # Add system prompt if provided


### PR DESCRIPTION
## Summary

This PR fixes the runtime issue where claude-trace finds broken pnpm wrappers, causing SyntaxError.

## Problem

Even after PR #201 was merged:
- ✅ claude-trace was correctly detected at /opt/homebrew/bin/claude-trace
- ✅ amplihack selected claude-trace
- ❌ BUT claude-trace found the broken pnpm wrapper at /Users/ryan/.local/share/pnpm/claude
- ❌ Node.js tried to execute the shell script as JavaScript → SyntaxError

## Solution

Tell claude-trace which claude binary to use via the `--claude-path` flag:

1. When using claude-trace, find the correct claude binary
2. Pass `--claude-path /opt/homebrew/bin/claude` to claude-trace
3. This prevents claude-trace from using problematic shell wrappers

## Implementation

Priority order for finding claude:
- `/opt/homebrew/bin/claude` (macOS homebrew - most reliable)
- `/usr/local/bin/claude` (Linux/WSL npm global)
- `/usr/bin/claude` (System-wide installation)
- Falls back to PATH search if none found

## Testing

Confirmed working:
```bash
# Command executed:
claude-trace --claude-path /opt/homebrew/bin/claude --run-with --dangerously-skip-permissions

# Result: ✅ No more SyntaxError!
```

## Impact

- Fixes the runtime issue that remained after PR #201
- Cross-platform support (macOS, Linux, WSL)
- No manual intervention required from users

🤖 Generated with [Claude Code](https://claude.ai/code)